### PR TITLE
Use exec() and print() functions in both Python 2 and Python 3

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -33,7 +33,7 @@ risk_env = os.environ.get('RISK_ENV', 'develop')
 # 若配置文件不存在，直接无法启动
 try:
     importlib.import_module('.' + risk_env, 'config')
-    exec 'from config.{risk_env} import *'.format(risk_env=risk_env)
+    exec('from config.{risk_env} import *'.format(risk_env=risk_env))
 except Exception:
     raise AssertionError(
         'The project should set correct RISK_ENV environment var.')

--- a/risk_models/strategy.py
+++ b/risk_models/strategy.py
@@ -99,7 +99,7 @@ class BoolStrategy(Strategy):
 
     def get_callable(self):
         threshold = self.threshold or None
-        return partial(BuiltInFuncs.run, builtin_func_name=self.__name__,
+        return partial(BuiltInFuncs.run, builtin_func_name=self.func_name,
                        op_name=self.op_name, threshold=threshold)
 
     @partial_bind_uuid
@@ -108,7 +108,7 @@ class BoolStrategy(Strategy):
             threshold = None
         else:
             threshold = threshold_list[0]
-        return partial(BuiltInFuncs.run, builtin_func_name=self.__name__,
+        return partial(BuiltInFuncs.run, builtin_func_name=self.func_name,
                        op_name=self.op_name, threshold=threshold)
 
 

--- a/risk_models/strategy.py
+++ b/risk_models/strategy.py
@@ -79,7 +79,7 @@ class BoolStrategy(Strategy):
 
     def __init__(self, d):
         super(BoolStrategy, self).__init__(d)
-        self.func_name = d['strategy_func']
+        self.__name__ = d['strategy_func']
         self.op_name = d['strategy_op']
         self.threshold = d['strategy_threshold']
         self.strategy_var = d['strategy_var']
@@ -99,7 +99,7 @@ class BoolStrategy(Strategy):
 
     def get_callable(self):
         threshold = self.threshold or None
-        return partial(BuiltInFuncs.run, builtin_func_name=self.func_name,
+        return partial(BuiltInFuncs.run, builtin_func_name=self.__name__,
                        op_name=self.op_name, threshold=threshold)
 
     @partial_bind_uuid
@@ -108,7 +108,7 @@ class BoolStrategy(Strategy):
             threshold = None
         else:
             threshold = threshold_list[0]
-        return partial(BuiltInFuncs.run, builtin_func_name=self.func_name,
+        return partial(BuiltInFuncs.run, builtin_func_name=self.__name__,
                        op_name=self.op_name, threshold=threshold)
 
 

--- a/risk_models/strategy.py
+++ b/risk_models/strategy.py
@@ -79,7 +79,7 @@ class BoolStrategy(Strategy):
 
     def __init__(self, d):
         super(BoolStrategy, self).__init__(d)
-        self.__name__ = d['strategy_func']
+        self.func_name = d['strategy_func']
         self.op_name = d['strategy_op']
         self.threshold = d['strategy_threshold']
         self.strategy_var = d['strategy_var']

--- a/www/core/generic.py
+++ b/www/core/generic.py
@@ -72,8 +72,7 @@ class PagedFilterTableView(SingleTableView):
             pages.append(current_page - 1)
             pages.append(current_page)
             pages.append(current_page + 1)
-        pages = list(set(pages))
-        pages.sort()
+        pages = sorted(set(pages))
         new_pages = [pages[0], ] if pages else []
         for i in range(1, len(pages)):
             gap = pages[i] - pages[i - 1]

--- a/www/core/lru.py
+++ b/www/core/lru.py
@@ -132,11 +132,8 @@ class LRUCacheDict(object):
         self.__expire_times.clear()
         self.__access_times.clear()
 
-    def __contains__(self, key):
-        return key in self
-
     @_lock_decorator
-    def has_key(self, key):
+    def __contains__(self, key):
         """
         This method should almost NEVER be used. The reason is that between the time
         has_key is called, and the key is accessed, the key might vanish.
@@ -146,7 +143,7 @@ class LRUCacheDict(object):
         >>> d['foo']
         'bar'
         >>> import time
-        >>> if d.has_key('foo'):
+        >>> if 'foo' in d:
         ...    time.sleep(2) #Oops, the key 'foo' is gone!
         ...    d['foo']
         Traceback (most recent call last):

--- a/www/core/lru.py
+++ b/www/core/lru.py
@@ -133,7 +133,7 @@ class LRUCacheDict(object):
         self.__access_times.clear()
 
     def __contains__(self, key):
-        return self.has_key(key)
+        return key in self
 
     @_lock_decorator
     def has_key(self, key):

--- a/www/rule/forms.py
+++ b/www/rule/forms.py
@@ -110,8 +110,7 @@ class RulesForm(BaseForm):
             self.errors['controls'] = [u'非法管控原子名']
         strategy_uuids = []
         for strategy in strategys_list:
-            item = strategy.split(';')
-            item.sort()
+            item = sorted(strategy.split(';'))
             strategy_uuids.append("".join(item))
         if len(set(strategy_uuids)) < len(strategy_uuids):
             self.errors['strategys'] = [u'策略原子有重复']

--- a/www/rule/views.py
+++ b/www/rule/views.py
@@ -170,8 +170,7 @@ class RulesChangeView(JSONResponseMixin, View):
         strategys = strategys_list
         strategy_uuids = []
         for strategy in strategys:
-            item = [x[0] for x in strategy]
-            item.sort()
+            item = sorted([x[0] for x in strategy])
             strategy_uuids.append("".join(item))
         if len(set(strategy_uuids)) < len(strategy_uuids):
             raise ValueError(u"策略原子有重复")

--- a/www/settings/settings.py
+++ b/www/settings/settings.py
@@ -135,7 +135,7 @@ risk_env = os.environ.get('RISK_ENV', 'develop')
 # 若配置文件不存在，直接无法启动
 try:
     importlib.import_module('.' + risk_env, 'settings.local_settings')
-    exec 'from local_settings.{risk_env} import *'.format(risk_env=risk_env)
+    exec('from local_settings.{risk_env} import *'.format(risk_env=risk_env))
 except Exception:
     raise AssertionError(
         'The project should set correct RISK_ENV environment var.')

--- a/www/strategy/forms.py
+++ b/www/strategy/forms.py
@@ -11,6 +11,7 @@ from builtin_funcs import BuiltInFuncs
 from core.redis_client import get_redis_client
 from core.forms import BaseForm, BaseFilterForm
 from core.pymongo_client import get_mongo_client
+from functools import reduce
 
 
 OP_CHOICES = (

--- a/www/strategy/largest_period.py
+++ b/www/strategy/largest_period.py
@@ -1,4 +1,5 @@
 # coding=utf8
+from __future__ import print_function
 import json
 from core.redis_client import get_redis_client
 
@@ -72,4 +73,4 @@ def get_source_largest_period():
 
 
 if __name__ == "__main__":
-    print get_source_largest_period()
+    print(get_source_largest_period())


### PR DESCRIPTION
Legacy __exec__ and __print__ statements are syntax errors in Python 3 but __exec()__ and __print()__ functions works as expected in both Python 2 and Python 3.